### PR TITLE
Count/find imaged moments by images and association link name

### DIFF
--- a/src/main/scala/org/mbari/vars/annotation/api/v1/ImagedMomentV1Api.scala
+++ b/src/main/scala/org/mbari/vars/annotation/api/v1/ImagedMomentV1Api.scala
@@ -22,7 +22,7 @@ import java.util.UUID
 import org.mbari.vars.annotation.controllers.ImagedMomentController
 import org.mbari.vars.annotation.dao.jpa.AnnotationImpl
 import org.mbari.vars.annotation.model.ImagedMoment
-import org.mbari.vars.annotation.model.simple.{ErrorMsg, ObservationCount, WindowRequest}
+import org.mbari.vars.annotation.model.simple.{ErrorMsg, ObservationCount, WindowRequest, Count}
 import org.mbari.vcr4j.time.Timecode
 import org.scalatra.{BadRequest, NoContent, NotFound}
 
@@ -54,7 +54,9 @@ class ImagedMomentV1Api(controller: ImagedMomentController)(implicit val executo
   get("/count/all") {
     controller
       .countAll()
-      .map(toJson)
+      .map(_.toLong)
+      .map(Count(_))
+      .map(toJson(_))
   }
 
   get("/find/images") {
@@ -66,13 +68,36 @@ class ImagedMomentV1Api(controller: ImagedMomentController)(implicit val executo
       .map(toJson)
   }
 
-  get("/find/boundingboxes") {
+  get("/count/images") {
+    controller
+      .countWithImages()
+      .map(_.toLong)
+      .map(Count(_))
+      .map(toJson(_))
+  }
+
+  get("/find/linkname/:linkname") {
+    val linkName = params
+      .get("linkname")
+      .getOrElse(halt(BadRequest(toJson(ErrorMsg(400, "Please provide a link name")))))
     val limit  = params.getAs[Int]("limit").orElse(Some(100))
     val offset = params.getAs[Int]("offset").orElse(Some(0))
     controller
-      .findWithBoundingBoxes(limit, offset)
+      .findByLinkName(linkName, limit, offset)
       .map(_.asJava)
       .map(toJson)
+  }
+
+  get("/count/linkname/:linkname") {
+    val linkName = params
+      .get("linkname")
+      .getOrElse(halt(BadRequest(toJson(ErrorMsg(400, "Please provide a link name")))))
+    
+    controller
+      .countByLinkName(linkName)
+      .map(_.toLong)
+      .map(Count(_))
+      .map(toJson(_))
   }
 
   get("/:uuid") {

--- a/src/main/scala/org/mbari/vars/annotation/api/v1/ImagedMomentV1Api.scala
+++ b/src/main/scala/org/mbari/vars/annotation/api/v1/ImagedMomentV1Api.scala
@@ -51,6 +51,30 @@ class ImagedMomentV1Api(controller: ImagedMomentController)(implicit val executo
       .map(toJson)
   }
 
+  get("/count/all") {
+    controller
+      .countAll()
+      .map(toJson)
+  }
+
+  get("/find/images") {
+    val limit  = params.getAs[Int]("limit").orElse(Some(100))
+    val offset = params.getAs[Int]("offset").orElse(Some(0))
+    controller
+      .findWithImages(limit, offset)
+      .map(_.asJava)
+      .map(toJson)
+  }
+
+  get("/find/boundingboxes") {
+    val limit  = params.getAs[Int]("limit").orElse(Some(100))
+    val offset = params.getAs[Int]("offset").orElse(Some(0))
+    controller
+      .findWithBoundingBoxes(limit, offset)
+      .map(_.asJava)
+      .map(toJson)
+  }
+
   get("/:uuid") {
     val uuid = params
       .getAs[UUID]("uuid")

--- a/src/main/scala/org/mbari/vars/annotation/controllers/ImagedMomentController.scala
+++ b/src/main/scala/org/mbari/vars/annotation/controllers/ImagedMomentController.scala
@@ -53,6 +53,21 @@ class ImagedMomentController(val daoFactory: BasicDAOFactory)
   ): Future[Iterable[ImagedMoment]] =
     exec(d => d.findAll(limit, offset))
 
+  def countAll()(
+      implicit ec: ExecutionContext
+  ): Future[Int] =
+    exec(d => d.countAll())
+  
+  def findWithImages(limit: Option[Int] = None, offset: Option[Int] = None)(
+      implicit ec: ExecutionContext
+  ): Future[Iterable[ImagedMoment]] =
+    exec(d => d.findWithImages(limit, offset))
+  
+  def findWithBoundingBoxes(limit: Option[Int] = None, offset: Option[Int] = None)(
+      implicit ec: ExecutionContext
+  ): Future[Iterable[ImagedMoment]] =
+    exec(d => d.findWithBoundingBoxes(limit, offset))
+
   def findAllVideoReferenceUUIDs(limit: Option[Int] = None, offset: Option[Int] = None)(
       implicit ec: ExecutionContext
   ): Future[Iterable[UUID]] =

--- a/src/main/scala/org/mbari/vars/annotation/controllers/ImagedMomentController.scala
+++ b/src/main/scala/org/mbari/vars/annotation/controllers/ImagedMomentController.scala
@@ -63,10 +63,20 @@ class ImagedMomentController(val daoFactory: BasicDAOFactory)
   ): Future[Iterable[ImagedMoment]] =
     exec(d => d.findWithImages(limit, offset))
   
-  def findWithBoundingBoxes(limit: Option[Int] = None, offset: Option[Int] = None)(
+  def countWithImages()(
+      implicit ec: ExecutionContext
+  ): Future[Int] =
+    exec(d => d.countWithImages())
+  
+  def findByLinkName(linkName: String, limit: Option[Int] = None, offset: Option[Int] = None)(
       implicit ec: ExecutionContext
   ): Future[Iterable[ImagedMoment]] =
-    exec(d => d.findWithBoundingBoxes(limit, offset))
+    exec(d => d.findByLinkName(linkName, limit, offset))
+  
+  def countByLinkName(linkName: String)(
+      implicit ec: ExecutionContext
+  ): Future[Int] = 
+    exec(d => d.countByLinkName(linkName))
 
   def findAllVideoReferenceUUIDs(limit: Option[Int] = None, offset: Option[Int] = None)(
       implicit ec: ExecutionContext

--- a/src/main/scala/org/mbari/vars/annotation/dao/ImagedMomentDAO.scala
+++ b/src/main/scala/org/mbari/vars/annotation/dao/ImagedMomentDAO.scala
@@ -79,6 +79,10 @@ trait ImagedMomentDAO[T <: ImagedMoment] extends DAO[T] {
       offset: Option[Int] = None
   ): java.util.stream.Stream[UUID]
 
+  def countAll(): Int
+  def findWithImages(limit: Option[Int], offset: Option[Int]): Iterable[T]
+  def findWithBoundingBoxes(limit: Option[Int], offset: Option[Int]): Iterable[T]
+
   def countByConcept(concept: String): Int
   def findByConcept(concept: String, limit: Option[Int], offset: Option[Int]): Iterable[T]
   def streamByConcept(

--- a/src/main/scala/org/mbari/vars/annotation/dao/ImagedMomentDAO.scala
+++ b/src/main/scala/org/mbari/vars/annotation/dao/ImagedMomentDAO.scala
@@ -80,8 +80,12 @@ trait ImagedMomentDAO[T <: ImagedMoment] extends DAO[T] {
   ): java.util.stream.Stream[UUID]
 
   def countAll(): Int
+
+  def countWithImages(): Int
   def findWithImages(limit: Option[Int], offset: Option[Int]): Iterable[T]
-  def findWithBoundingBoxes(limit: Option[Int], offset: Option[Int]): Iterable[T]
+
+  def countByLinkName(linkName: String): Int
+  def findByLinkName(linkName: String, limit: Option[Int], offset: Option[Int]): Iterable[T]
 
   def countByConcept(concept: String): Int
   def findByConcept(concept: String, limit: Option[Int], offset: Option[Int]): Iterable[T]

--- a/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentDAOImpl.scala
+++ b/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentDAOImpl.scala
@@ -294,6 +294,25 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
       offset: Option[Int] = None
   ): Iterable[ImagedMomentImpl] =
     findByNamedQuery("ImagedMoment.findAll", limit = limit, offset = offset)
+  
+  override def countAll(): Int =
+    entityManager.createNamedQuery("ImagedMoment.countAll")
+      .getResultList
+      .asScala
+      .map(_.toString().toInt)
+      .head
+  
+  override def findWithImages(
+    limit: Option[Int], 
+    offset: Option[Int]
+  ): Iterable[ImagedMomentImpl] =
+    findByNamedQuery("ImagedMoment.findWithImages", limit = limit, offset = offset)
+
+  override def findWithBoundingBoxes(
+    limit: Option[Int], 
+    offset: Option[Int]
+  ): Iterable[ImagedMomentImpl] =
+    findByNamedQuery("ImagedMoment.findWithBoundingBoxes", limit = limit, offset = offset)
 
   override def findByVideoReferenceUUIDAndElapsedTime(
       uuid: UUID,

--- a/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentDAOImpl.scala
+++ b/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentDAOImpl.scala
@@ -308,11 +308,37 @@ class ImagedMomentDAOImpl(entityManager: EntityManager)
   ): Iterable[ImagedMomentImpl] =
     findByNamedQuery("ImagedMoment.findWithImages", limit = limit, offset = offset)
 
-  override def findWithBoundingBoxes(
+  override def countWithImages(): Int =
+    entityManager.createNamedQuery("ImagedMoment.countWithImages")
+      .getResultList
+      .asScala
+      .map(_.toString().toInt)
+      .head
+
+  override def findByLinkName(
+    linkName: String,
     limit: Option[Int], 
     offset: Option[Int]
   ): Iterable[ImagedMomentImpl] =
-    findByNamedQuery("ImagedMoment.findWithBoundingBoxes", limit = limit, offset = offset)
+    findByNamedQuery(
+      "ImagedMoment.findByLinkName", 
+      Map("linkName" -> linkName), 
+      limit = limit, offset = offset
+    )
+  
+  override def countByLinkName(
+    linkName: String
+  ): Int = {
+    val query = entityManager.createNamedQuery("ImagedMoment.countByLinkName")
+
+    query.setParameter(1, linkName)
+
+    query
+      .getResultList
+      .asScala
+      .map(_.toString().toInt)
+      .head
+  }
 
   override def findByVideoReferenceUUIDAndElapsedTime(
       uuid: UUID,

--- a/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentImpl.scala
+++ b/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentImpl.scala
@@ -115,6 +115,10 @@ import scala.collection.mutable
     new NamedNativeQuery(
       name = "ImagedMoment.countByVideoReferenceUUID",
       query = "SELECT COUNT(*) FROM imaged_moments WHERE video_reference_uuid = ?1"
+    ),
+    new NamedNativeQuery(
+      name = "ImagedMoment.countAll",
+      query = "SELECT COUNT(*) FROM imaged_moments"
     )
   )
 )
@@ -123,6 +127,19 @@ import scala.collection.mutable
     new NamedQuery(
       name = "ImagedMoment.findAll",
       query = "SELECT i FROM ImagedMoment i ORDER BY i.uuid"
+    ),
+    new NamedQuery(
+      name = "ImagedMoment.findWithImages",
+      query = "SELECT i FROM ImagedMoment i " +
+        "LEFT JOIN i.javaImageReferences ir " +
+        "WHERE ir.url IS NOT NULL"
+    ),
+    new NamedQuery(
+      name = "ImagedMoment.findWithBoundingBoxes",
+      query = "SELECT i FROM ImagedMoment i " + 
+        "INNER JOIN i.javaObservations o " +
+        "INNER JOIN o.javaAssociations a " +
+        "WHERE a.linkName = 'bounding box'"
     ),
     new NamedQuery(
       name = "ImagedMoment.findByConcept",

--- a/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentImpl.scala
+++ b/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentImpl.scala
@@ -119,6 +119,13 @@ import scala.collection.mutable
     new NamedNativeQuery(
       name = "ImagedMoment.countAll",
       query = "SELECT COUNT(*) FROM imaged_moments"
+    ),
+    new NamedNativeQuery(
+      name = "ImagedMoment.countByLinkName",
+      query = "SELECT COUNT(*) FROM imaged_moments i " + 
+        "INNER JOIN observations o ON o.imaged_moment_uuid = i.uuid " +
+        "INNER JOIN associations a ON a.observation_uuid = o.uuid " +
+        "WHERE a.link_name = ?1"
     )
   )
 )
@@ -135,11 +142,11 @@ import scala.collection.mutable
         "WHERE ir.url IS NOT NULL"
     ),
     new NamedQuery(
-      name = "ImagedMoment.findWithBoundingBoxes",
+      name = "ImagedMoment.findByLinkName",
       query = "SELECT i FROM ImagedMoment i " + 
         "INNER JOIN i.javaObservations o " +
         "INNER JOIN o.javaAssociations a " +
-        "WHERE a.linkName = 'bounding box'"
+        "WHERE a.linkName = :linkName"
     ),
     new NamedQuery(
       name = "ImagedMoment.findByConcept",

--- a/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentImpl.scala
+++ b/src/main/scala/org/mbari/vars/annotation/dao/jpa/ImagedMomentImpl.scala
@@ -121,6 +121,12 @@ import scala.collection.mutable
       query = "SELECT COUNT(*) FROM imaged_moments"
     ),
     new NamedNativeQuery(
+      name = "ImagedMoment.countWithImages",
+      query = "SELECT COUNT(*) FROM imaged_moments i " + 
+        "INNER JOIN image_references ir ON ir.imaged_moment_uuid = i.uuid " +
+        "WHERE ir.url IS NOT NULL"
+    ),
+    new NamedNativeQuery(
       name = "ImagedMoment.countByLinkName",
       query = "SELECT COUNT(*) FROM imaged_moments i " + 
         "INNER JOIN observations o ON o.imaged_moment_uuid = i.uuid " +

--- a/src/test/scala/org/mbari/vars/annotation/api/v1/ImagedMomentV1ApiSpec.scala
+++ b/src/test/scala/org/mbari/vars/annotation/api/v1/ImagedMomentV1ApiSpec.scala
@@ -17,14 +17,15 @@
 package org.mbari.vars.annotation.api.v1
 
 import java.time.{Duration, Instant}
+import java.net.URL
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import org.mbari.vars.annotation.api.WebApiStack
-import org.mbari.vars.annotation.controllers.{AnnotationController, ImagedMomentController}
+import org.mbari.vars.annotation.controllers.{AnnotationController, ImagedMomentController, ImageController, AssociationController}
 import org.mbari.vars.annotation.dao.jpa.ImagedMomentImpl
 import org.mbari.vars.annotation.model.Annotation
-import org.mbari.vars.annotation.model.simple.WindowRequest
+import org.mbari.vars.annotation.model.simple.{WindowRequest, Count}
 
 import scala.concurrent.Await
 import scala.concurrent.duration.{Duration => SDuration}
@@ -134,6 +135,14 @@ class ImagedMomentV1ApiSpec extends WebApiStack {
     }
   }
 
+  it should "count all imagedmoments" in {
+    get("/v1/imagedmoments/count/all") {
+      status should be(200)
+      val count = gson.fromJson(body, classOf[Count])
+      count.count.toInt should be > 0
+    }
+  }
+
   it should "update" in {
     put(
       s"/v1/imagedmoments/${annotation.imagedMomentUuid}",
@@ -151,6 +160,106 @@ class ImagedMomentV1ApiSpec extends WebApiStack {
     delete(s"/v1/imagedmoments/${annotation.imagedMomentUuid}") {
       status should be(204)
     }
+  }
+
+  it should "count and find with images" in {
+
+    val recordedDate = Some(Instant.now())
+    val url = new URL("http://foo.bar/image.png")
+
+    val image = {
+      val imageController = new ImageController(daoFactory)
+      Await.result(
+        imageController.create(
+          UUID.randomUUID(), // video reference UUID
+          url,
+          recordedDate = recordedDate
+        ),
+        SDuration(3000, TimeUnit.MILLISECONDS)
+      )
+    }
+
+    val targetImagedMomentUUID = image.imagedMomentUuid
+
+    // Check count > 0
+    get("/v1/imagedmoments/count/images") {
+      status should be(200)
+      val count = gson.fromJson(body, classOf[Count])
+      count.count.toInt should be > 0
+    }
+
+    // Find imaged moment, check UUID and image reference URL match
+    get("/v1/imagedmoments/find/images") {
+      status should be(200)
+      val im = gson.fromJson(body, classOf[Array[ImagedMomentImpl]]).toList
+      im.size should be > 0
+      val i = im.head
+      i.uuid should be(targetImagedMomentUUID)
+      i.imageReferences.head.url should be(url)
+    }
+
+  }
+
+  it should "count and find by link name" in {
+
+    val linkName = "foo"
+    val toConcept = "self"
+    val linkValue = "bar"
+
+    val annotation = {
+      val annotationController = new AnnotationController(daoFactory)
+      Await.result(
+        annotationController.create(
+          UUID.randomUUID(),  // video reference UUID
+          "Bar",
+          "kbarnard",
+          elapsedTime = Some(Duration.ofMillis(42)),
+          recordedDate = Some(Instant.now())
+        ),
+        SDuration(3000, TimeUnit.MILLISECONDS)
+      )
+    }
+
+    val association = {
+      val associationController = new AssociationController(daoFactory)
+      Await.result(
+        associationController.create(
+          annotation.observationUuid,
+          linkName,
+          toConcept,
+          linkValue,
+          "text/plain"
+        ),
+        SDuration(3000, TimeUnit.MILLISECONDS)
+      )
+    }
+
+    // Check count > 0 for given link name
+    get(s"/v1/imagedmoments/count/linkname/${linkName}") {
+      status should be(200)
+      val count = gson.fromJson(body, classOf[Count])
+      count.count.toInt should be > 0
+    }
+
+    // Find imaged moment, check UUID and link name match
+    get(s"/v1/imagedmoments/find/linkname/${linkName}") {
+      status should be(200)
+
+      val im = gson.fromJson(body, classOf[Array[ImagedMomentImpl]]).toList
+      im.size should be > 0
+      
+      val i = im.head
+      i.uuid should be(annotation.imagedMomentUuid)
+
+      // Pull out the association
+      val o = i.observations.head
+      val a = o.associations.head
+
+      a.uuid should be(association.uuid)
+      a.linkName should be(linkName)
+      a.linkValue should be(linkValue)
+    }
+
   }
 
 }


### PR DESCRIPTION
Added endpoints:
1. `/v1/imagedmoments/count/all` returns a count of all imaged moments
2. `/v1/imagedmoments/count/images` returns a count of imaged moments with at least one valid (non-null URL) image reference
3. `/v1/imagedmoments/find/images` returns the imaged moments " " " "
4. `/v1/imagedmoments/count/linkname/:linkname` returns a count of imaged moments with at least one association with the given link name
5. `/v1/imagedmoments/find/linkname/:linkname` returns the imaged moments " " " "

Unit tests to cover each new endpoint are included.